### PR TITLE
burndown chart

### DIFF
--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -122,7 +122,7 @@ export async function GET(request: Request) {
     taskBacklogHistory = await prisma.task_backlog.findMany({
       where: {
         createdAt: {
-          gte: new Date("2025-09-12T00:00:00Z"),
+          gte: new Date("2025-11-17T00:00:00Z"),
         },
       },
       select: {

--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -122,7 +122,7 @@ export async function GET(request: Request) {
     taskBacklogHistory = await prisma.task_backlog.findMany({
       where: {
         createdAt: {
-          gte: new Date(new Date().setMonth(new Date().getMonth() - 6)),
+          gte: new Date("2025-11-03T00:00:00Z"),
         },
       },
       select: {

--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -122,7 +122,7 @@ export async function GET(request: Request) {
     taskBacklogHistory = await prisma.task_backlog.findMany({
       where: {
         createdAt: {
-          gte: new Date("2025-11-03T00:00:00Z"),
+          gte: new Date("2025-09-12T00:00:00Z"),
         },
       },
       select: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,6 +33,7 @@ export default function Component() {
     currentActivityStartTime,
     taskBacklogHistory,
     neutralActivity,
+    dailyIdealBurndown,
     fetchData,
   } = useDashboardData();
 
@@ -114,6 +115,7 @@ export default function Component() {
                 showOnlyMA={showOnlyMA}
                 taskBacklogRefreshesLeft={taskBacklogRefreshesLeft}
                 neutralActivity={neutralActivity}
+                dailyIdealBurndown={dailyIdealBurndown}
               />
               <WeeklyProductiveFlowChart
                 weeklyProductiveFlowData={weeklyProductiveFlowData}

--- a/app/personal/page.tsx
+++ b/app/personal/page.tsx
@@ -115,6 +115,7 @@ export default function Component() {
                 showOnlyMA={showOnlyMA}
                 taskBacklogRefreshesLeft={taskBacklogRefreshesLeft}
                 neutralActivity={neutralActivity}
+                dailyIdealBurndown={dailyIdealBurndown}
               />
               <WeeklyProductiveFlowChart
                 weeklyProductiveFlowData={weeklyProductiveFlowData}

--- a/components/area.tsx
+++ b/components/area.tsx
@@ -27,6 +27,7 @@ export default function AreaGraph({
   timeUnits,
   liveCategory,
   neutralActivity,
+  burndownLines,
 }: {
   data?:
     | ChartData[]

--- a/components/dashboard/TaskBacklogChart.tsx
+++ b/components/dashboard/TaskBacklogChart.tsx
@@ -2,6 +2,7 @@
 
 import AreaGraph from "@/components/area";
 import { task_backlog } from "@prisma/client";
+import { useMemo } from "react";
 
 interface TaskBacklogChartProps {
   taskBacklogHistory: Pick<task_backlog, "id" | "amount" | "createdAt">[];
@@ -11,6 +12,27 @@ interface TaskBacklogChartProps {
   neutralActivity: boolean;
 }
 
+// Calculate linear regression (line of best fit) from data points
+function calculateLinearRegression(dataPoints: { x: number; y: number }[]): {
+  slope: number;
+  intercept: number;
+} {
+  const n = dataPoints.length;
+  if (n < 2) {
+    return { slope: 0, intercept: dataPoints[0]?.y || 0 };
+  }
+
+  const sumX = dataPoints.reduce((sum, p) => sum + p.x, 0);
+  const sumY = dataPoints.reduce((sum, p) => sum + p.y, 0);
+  const sumXY = dataPoints.reduce((sum, p) => sum + p.x * p.y, 0);
+  const sumXX = dataPoints.reduce((sum, p) => sum + p.x * p.x, 0);
+
+  const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+  const intercept = (sumY - slope * sumX) / n;
+
+  return { slope, intercept };
+}
+
 export default function TaskBacklogChart({
   taskBacklogHistory,
   flow,
@@ -18,36 +40,207 @@ export default function TaskBacklogChart({
   taskBacklogRefreshesLeft,
   neutralActivity,
 }: TaskBacklogChartProps) {
+  const chartData = useMemo(() => {
+    if (taskBacklogHistory.length === 0) return [];
+
+    // Group data into 4-hour intervals and calculate averages
+    const FOUR_HOURS = 4 * 60 * 60 * 1000; // milliseconds in 4 hours
+    const grouped = new Map<
+      number,
+      { amounts: number[]; timestamps: number[] }
+    >();
+
+    taskBacklogHistory.forEach((item) => {
+      const timestamp = new Date(item.createdAt).getTime();
+      const intervalStart = Math.floor(timestamp / FOUR_HOURS) * FOUR_HOURS;
+
+      if (!grouped.has(intervalStart)) {
+        grouped.set(intervalStart, { amounts: [], timestamps: [] });
+      }
+      grouped.get(intervalStart)!.amounts.push(item.amount);
+      grouped.get(intervalStart)!.timestamps.push(timestamp);
+    });
+
+    // Convert to array and calculate averages
+    const baseData = Array.from(grouped.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([intervalStart, data], index, array) => {
+        const avgAmount =
+          data.amounts.reduce((sum, val) => sum + val, 0) / data.amounts.length;
+        const avgTimestamp =
+          data.timestamps.reduce((sum, val) => sum + val, 0) /
+          data.timestamps.length;
+        const date = new Date(avgTimestamp);
+
+        return {
+          day: `interval-${intervalStart}`,
+          "hours of planned tasks left": avgAmount,
+          date:
+            index === array.length - 1
+              ? "LIVE"
+              : `${date.toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                })} ${date.toLocaleTimeString("en-GB", {
+                  hour: "numeric",
+                  minute: "2-digit",
+                  hour12: true,
+                })}`,
+          timestamp: avgTimestamp,
+          amount: avgAmount,
+        };
+      });
+
+    if (baseData.length === 0) return baseData;
+
+    // Get the last 7 days of data for linear regression
+    const now = Date.now();
+    const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000;
+    const recentData = baseData.filter(
+      (item) =>
+        item.timestamp >= sevenDaysAgo &&
+        item.amount !== null &&
+        item.amount !== undefined
+    );
+
+    const currentBacklog = baseData[baseData.length - 1]?.amount || 0;
+    const currentTimestamp = baseData[baseData.length - 1].timestamp;
+    const idealBurndownRate = 8; // hours per day
+
+    // Calculate projected line using linear regression on last 7 days
+    let projectedSlope = 0;
+    let projectedIntercept = currentBacklog;
+
+    if (recentData.length >= 2) {
+      const recentFirstTimestamp = recentData[0].timestamp;
+      const regressionPoints = recentData.map((item) => ({
+        x: (item.timestamp - recentFirstTimestamp) / (24 * 60 * 60 * 1000),
+        y: item.amount,
+      }));
+
+      const regression = calculateLinearRegression(regressionPoints);
+      projectedSlope = regression.slope;
+      projectedIntercept = regression.intercept;
+    }
+
+    // Add burndown values to existing data points
+    const dataWithBurndown = baseData.map((item) => {
+      const daysFromCurrent =
+        (item.timestamp - currentTimestamp) / (24 * 60 * 60 * 1000);
+
+      // Ideal: starts from current point, 8 hr/day
+      const idealValue =
+        daysFromCurrent >= 0
+          ? Math.max(0, currentBacklog - daysFromCurrent * idealBurndownRate)
+          : null;
+
+      // Projected: line of best fit from last 7 days
+      let projectedValue = null;
+      if (recentData.length >= 2) {
+        const recentFirstTimestamp = recentData[0].timestamp;
+        const daysFromRecentFirst =
+          (item.timestamp - recentFirstTimestamp) / (24 * 60 * 60 * 1000);
+        if (daysFromRecentFirst >= 0) {
+          projectedValue = Math.max(
+            0,
+            projectedSlope * daysFromRecentFirst + projectedIntercept
+          );
+        }
+      }
+
+      return {
+        ...item,
+        "ideal burndown": idealValue,
+        "projected burndown": projectedValue,
+      };
+    });
+
+    // Add future projection points (extend both lines to zero) in 4-hour intervals
+    const futurePoints = [];
+    const lastTimestamp = baseData[baseData.length - 1].timestamp;
+
+    // Calculate how far to extend
+    const daysToZeroIdeal = currentBacklog / idealBurndownRate;
+    const daysToZeroProjected =
+      projectedSlope < 0
+        ? -projectedIntercept / projectedSlope
+        : daysToZeroIdeal;
+    const maxDays = Math.min(
+      Math.ceil(Math.max(daysToZeroIdeal, daysToZeroProjected)),
+      60
+    );
+
+    // Generate future points at 4-hour intervals
+    const maxFutureTimestamp = lastTimestamp + maxDays * 24 * 60 * 60 * 1000;
+    let futureTimestamp = lastTimestamp + FOUR_HOURS;
+    let intervalIndex = 1;
+
+    while (futureTimestamp <= maxFutureTimestamp) {
+      const futureDate = new Date(futureTimestamp);
+      const futureDateStr = `${futureDate.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      })} ${futureDate.toLocaleTimeString("en-GB", {
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      })}`;
+
+      const daysFromCurrent =
+        (futureTimestamp - currentTimestamp) / (24 * 60 * 60 * 1000);
+      const idealValue = Math.max(
+        0,
+        currentBacklog - daysFromCurrent * idealBurndownRate
+      );
+
+      const recentFirstTimestamp = recentData[0]?.timestamp || currentTimestamp;
+      const daysFromRecentFirst =
+        (futureTimestamp - recentFirstTimestamp) / (24 * 60 * 60 * 1000);
+      const projectedValue = Math.max(
+        0,
+        projectedSlope * daysFromRecentFirst + projectedIntercept
+      );
+
+      futurePoints.push({
+        day: `future-${intervalIndex}`,
+        "hours of planned tasks left": null,
+        date: futureDateStr,
+        timestamp: futureTimestamp,
+        amount: null,
+        "ideal burndown": idealValue,
+        "projected burndown": projectedValue,
+      });
+
+      // Stop if both lines reached zero
+      if (idealValue === 0 && projectedValue === 0) break;
+
+      futureTimestamp += FOUR_HOURS;
+      intervalIndex++;
+    }
+
+    return [...dataWithBurndown, ...futurePoints];
+  }, [taskBacklogHistory]);
+
   return (
     <AreaGraph
-      data={taskBacklogHistory.map((item, index) => ({
-        day: item.id,
-        "hours of planned tasks left": item.amount,
-        date:
-          index === taskBacklogHistory.length - 1
-            ? "LIVE"
-            : `${new Date(item.createdAt).toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-              })} ${new Date(item.createdAt).toLocaleTimeString("en-GB", {
-                hour: "numeric",
-                minute: "2-digit",
-                hour12: true,
-              })}`,
-      }))}
+      data={chartData}
       className="h-[40vh]"
       title={"Hours of Planned Tasks Left (h)"}
-      categories={["hours of planned tasks left"]}
+      categories={[
+        "hours of planned tasks left",
+        "projected burndown",
+        "ideal burndown",
+      ]}
       colors={
         showOnlyMA
-          ? ["slate"]
+          ? ["slate", "gray", "zinc"]
           : flow > 2.5
-          ? ["red", "gray"]
+          ? ["red", "gray", "zinc"]
           : flow > 1.5
-          ? ["fuchsia", "slate"]
+          ? ["fuchsia", "gray", "zinc"]
           : flow > 0.8334
-          ? ["emerald", "slate"]
-          : ["blue", "slate"]
+          ? ["emerald", "gray", "zinc"]
+          : ["blue", "gray", "zinc"]
       }
       index={"date"}
       minutesLeft={taskBacklogRefreshesLeft / 4}

--- a/components/dashboard/TaskBacklogChart.tsx
+++ b/components/dashboard/TaskBacklogChart.tsx
@@ -45,15 +45,6 @@ export default function TaskBacklogChart({
   const chartData = useMemo(() => {
     if (taskBacklogHistory.length === 0) return [];
 
-    console.log("📈 TaskBacklogChart Debug:");
-    console.log("  - Total history entries:", taskBacklogHistory.length);
-    console.log(
-      "  - Last 3 entries:",
-      taskBacklogHistory
-        .slice(-3)
-        .map((h) => ({ amount: h.amount, date: h.createdAt }))
-    );
-
     // Separate the LIVE point (last entry) from historical data
     const livePoint = taskBacklogHistory[taskBacklogHistory.length - 1];
     const historicalData = taskBacklogHistory.slice(0, -1);
@@ -143,15 +134,6 @@ export default function TaskBacklogChart({
       // Convert daily rate to 4-hour interval rate (1 day = 6 intervals of 4 hours)
       return dailyRate / 6;
     };
-
-    console.log("  - After 4hr aggregation, entries:", baseData.length);
-    console.log("  - Current backlog (last point):", currentBacklog);
-    console.log("  - Last aggregated point:", baseData[baseData.length - 1]);
-    console.log(
-      "  - Daily ideal burndown rates:",
-      Object.keys(dailyIdealBurndown).length,
-      "days"
-    );
 
     // Calculate projected line using linear regression on last 7 days
     let projectedSlope = 0;
@@ -271,9 +253,6 @@ export default function TaskBacklogChart({
     }
 
     const finalData = [...dataWithBurndown, ...futurePoints];
-    console.log("  - Final chart data length:", finalData.length);
-    console.log("  - Last data point:", finalData[finalData.length - 1]);
-    console.log("  - Second to last:", finalData[finalData.length - 2]);
 
     return finalData;
   }, [taskBacklogHistory, dailyIdealBurndown]);

--- a/components/tremor/AreaChart.tsx
+++ b/components/tremor/AreaChart.tsx
@@ -957,10 +957,17 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>(
                           />
                         );
                       }
-                      if (
-                        data.length - 1 === index &&
-                        liveCategory === category
-                      ) {
+                      // Check if this is the LIVE point: has non-null value for liveCategory
+                      // and is either last point OR next point has null for liveCategory
+                      const isLivePoint =
+                        liveCategory === category &&
+                        props.value !== null &&
+                        props.value !== undefined &&
+                        (index === data.length - 1 ||
+                          !data[index + 1]?.[category] ||
+                          data[index + 1]?.[category] === null);
+
+                      if (isLivePoint) {
                         return (
                           <React.Fragment key={index}>
                             {liveCategory == category && (

--- a/components/tremor/AreaChart.tsx
+++ b/components/tremor/AreaChart.tsx
@@ -706,7 +706,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>(
               )}
               tickLine={false}
               axisLine={false}
-              minTickGap={tickGap}
+              minTickGap={80}
             >
               {xAxisLabel && (
                 <Label

--- a/components/tremor/AreaChart.tsx
+++ b/components/tremor/AreaChart.tsx
@@ -872,6 +872,12 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>(
                         ? 0.3
                         : 1
                     }
+                    strokeDasharray={
+                      category === "projected burndown" ||
+                      category === "ideal burndown"
+                        ? "5 5"
+                        : undefined
+                    }
                     activeDot={(props: any) => {
                       const {
                         cx: cxCoord,

--- a/hooks/useDashboardData.ts
+++ b/hooks/useDashboardData.ts
@@ -121,6 +121,11 @@ export function useDashboardData() {
           neutralActivity: newNeutralActivity,
         } = unprocessedData;
 
+        console.log("📊 Task Backlog Debug:");
+        console.log("  - taskBacklog from server:", taskBacklog);
+        console.log("  - taskBacklogHistory from DB:", newTaskBacklogHistoryData.slice(-3));
+        console.log("  - Creating LIVE point with amount:", taskBacklog);
+        
         setTaskBacklogRefreshesLeft(newTbRefreshesLeft);
         setTaskBacklogHistory([
           ...newTaskBacklogHistoryData,

--- a/hooks/useDashboardData.ts
+++ b/hooks/useDashboardData.ts
@@ -123,11 +123,6 @@ export function useDashboardData() {
           dailyIdealBurndown: newDailyIdealBurndown,
         } = unprocessedData;
 
-        console.log("📊 Task Backlog Debug:");
-        console.log("  - taskBacklog from server:", taskBacklog);
-        console.log("  - taskBacklogHistory from DB:", newTaskBacklogHistoryData.slice(-3));
-        console.log("  - Creating LIVE point with amount:", taskBacklog);
-        
         setTaskBacklogRefreshesLeft(newTbRefreshesLeft);
         setTaskBacklogHistory([
           ...newTaskBacklogHistoryData,

--- a/hooks/useDashboardData.ts
+++ b/hooks/useDashboardData.ts
@@ -76,6 +76,7 @@ export function useDashboardData() {
     Pick<task_backlog, "id" | "amount" | "createdAt">[]
   >([]);
   const [neutralActivity, setNeutralActivity] = useState(false);
+  const [dailyIdealBurndown, setDailyIdealBurndown] = useState<{ [key: string]: number }>({});
 
   const fetchData = useCallback(
     async (errorMessage: string) => {
@@ -119,6 +120,7 @@ export function useDashboardData() {
           taskBacklogRefreshesLeft: newTbRefreshesLeft,
           taskBacklogHistory: newTaskBacklogHistoryData,
           neutralActivity: newNeutralActivity,
+          dailyIdealBurndown: newDailyIdealBurndown,
         } = unprocessedData;
 
         console.log("📊 Task Backlog Debug:");
@@ -132,6 +134,7 @@ export function useDashboardData() {
           { id: cuid(), amount: taskBacklog, createdAt: new Date() },
         ]);
         setNeutralActivity(newNeutralActivity);
+        setDailyIdealBurndown(newDailyIdealBurndown || {});
         setFlow(newCurrentActivity === "😴 Sleeping" ? 0 : newFlow);
         setStartDate(newStartDate);
         setEndDate(newEndDate);
@@ -294,6 +297,7 @@ export function useDashboardData() {
     currentActivityStartTime,
     taskBacklogHistory,
     neutralActivity,
+    dailyIdealBurndown,
     fetchData, // Exporting fetchData for CountdownComponent's refresh
   };
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -93,6 +93,7 @@ export declare interface MetricsResponse {
   taskBacklogRefreshesLeft: number;
   neutralActivity: boolean;
   taskBacklogDetails: Record<string, string | number>[];
+  dailyIdealBurndown?: { [key: string]: number };
   // efficiencyList: (presumably an array of numbers or a specific object structure)
 }
 


### PR DESCRIPTION
- **mvp burndown chart**
- **colour code and dot the lines**
- **fix line of best fit and start date**
- **add back live point and don't include current backlog in the 4h average**
- **calendar backed ideal burndown**
- **remove debug logs**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds dashed ideal and projected burndown lines to the Task Backlog chart with 4-hour aggregation and improved LIVE-point logic, wires calendar-backed dailyIdealBurndown from API, tweaks axis ticks, and fixes backlog history start date filter.
> 
> - **Charts (Task Backlog)**:
>   - Add `ideal burndown` and `projected burndown` series; extend future points; color projected line based on recent slope vs ideal.
>   - Aggregate historical backlog into 4-hour intervals; keep last point as LIVE.
>   - Update categories and dynamic colors; show dashed styling for burndown lines; refine LIVE-point dot rendering.
> - **Data flow**:
>   - Plumb `dailyIdealBurndown` from API through `useDashboardData` to `TaskBacklogChart` and consuming pages (`app/page.tsx`, `app/personal/page.tsx`).
>   - Extend `MetricsResponse` with optional `dailyIdealBurndown`.
> - **UI tweaks**:
>   - Increase X-axis `minTickGap` to `80` for readability.
> - **Backend**:
>   - Change backlog history query start date to fixed `gte: new Date("2025-11-17T00:00:00Z")`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e645e80441ab70e2d33f41ed54f0c52a3857dc59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->